### PR TITLE
Add a server schema if needed

### DIFF
--- a/release.py
+++ b/release.py
@@ -367,6 +367,8 @@ def parse_and_combine_args():
     config = None
     if args.config:
         config = parse_config(args.config)
+        jira_server = config['jira-server']
+        config['jira-server'] = 'https://{}'.format(jira_server) if 'http' not in jira_server else jira_server
     if not config:
         return args
 


### PR DESCRIPTION
The script is able to operate with both a schema-less and a full domain string.
E.g. `tangle.atlassian.net` and `https://tangle.atlassian.net`.

Sorry for childish code but it's a really quick fix. Would appreciate suggestions how to rewrite it in a better way.