### PR TITLE
Add a step creating tokenized remote

### DIFF
--- a/release.py
+++ b/release.py
@@ -279,7 +279,7 @@ class API:
 
     @cached_property
     def github_repository(self):
-        return self.github.get_repo(github_repo_name.github_repo_name)
+        return self.github.get_repo(self.github_repo_name)
 
 
 def run(commands, api_client, jira_task_extra, task_key, task_re,


### PR DESCRIPTION
### Description
Everybody should be able to deal with a release script but this is not the case due to restrictions. There is an allmighty bot created for this purpose. But the script have not used a token to push branches.

### Changes
* Prepare a special remote which contains a bot's user name and it's token.
* User this remote to push branches.

**Disclaimer:** I have not test a full blown procedure but have tested 2 cases: no origin created & the origin has already been created,